### PR TITLE
chore: switch Trivy build to local image

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -73,12 +73,8 @@ jobs:
         with:
           ref: ${{needs.prepare-env.outputs.check_sha}}
 
-      - name: Login to Docker Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build docker image
+        run: ./gradlew jibDockerBuild -x test --image=${{ env.REGISTRY }}/${{ github.repository }}:${{needs.prepare-env.outputs.check_sha}}
 
       - name: Run Trivy vulnerability scanner
         if: always()


### PR DESCRIPTION
Pulling from the eclipse-tractusx registry has login issues.